### PR TITLE
fix: support the case where content_type = 'application/json; charset…

### DIFF
--- a/utils/mcp_client.py
+++ b/utils/mcp_client.py
@@ -259,7 +259,7 @@ class McpStreamableHttpClient(McpClient):
                 if sse.event != "message":
                     raise Exception(f"{self.name} - Unknown Server-Sent Event: {sse.event}")
                 message = json.loads(sse.data)
-        elif content_type == "application/json":
+        elif "application/json" in content_type:
             message = (response.json() if response.content else None) or {}
         else:
             raise Exception(f"{self.name} - Unsupported Content-Type: {content_type}")


### PR DESCRIPTION
当 MCP-SERVER 响应头中的 `content-type` 为 'application/json; charset=utf-8' 时，插件需要做兼容性处理

![image](https://github.com/user-attachments/assets/e060eb5d-04c4-4b1a-b7ef-4c6e47f7c085)
![image](https://github.com/user-attachments/assets/5a120429-330a-4fdd-825c-84484f26328f)
@junjiem 
