### PR TITLE
fix: LLM list cannot be selected

### DIFF
--- a/strategies/function_calling.yaml
+++ b/strategies/function_calling.yaml
@@ -12,7 +12,7 @@ features:
 parameters:
   - name: model
     type: model-selector
-    scope: tool-call&llm
+    scope: llm
     required: true
     label:
       en_US: Model


### PR DESCRIPTION
`FunctionCalling` 策略的 `Scope` 需要改成 `llm`，否则会出现大量的模型被隐藏无法选择

修改前：
![image](https://github.com/user-attachments/assets/622d47b0-866a-4617-8c88-57a9a17a3c3a)

----
修改后：
![企业微信截图_17484916112232](https://github.com/user-attachments/assets/55442b48-8e3d-4bfc-b2a5-76ebb3fb5cb6)
@junjiem 