### PR TITLE
Trim Trailing Whitespace from Messages Before Sending to Claude

### DIFF
--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -191,6 +191,12 @@ class ReActAgentStrategy(AgentStrategy):
                 self.recalc_llm_max_tokens(
                     model.entity, prompt_messages, model.completion_params
                 )
+
+            # prevent Claude LLM errors caused by extra whitespace.
+            for i, msg in enumerate(prompt_messages):
+                if hasattr(msg, "content") and isinstance(msg.content, str):
+                    msg.content = msg.content.strip()
+
             # invoke model
             chunks = self.session.model.llm.invoke(
                 model_config=LLMModelConfig(**model.model_dump(mode="json")),


### PR DESCRIPTION
## Description
Fix issue when sending messages to Claude LLM: if the final assistant message ends with trailing whitespace, the API returns:

```
ValidationException: final assistant content cannot end with trailing whitespace
```
## Fix
Trim trailing whitespace from each message before sending to Claude.
fixed #119 
