### PR TITLE
feat: add MCP call interval support for rate limiting

### DIFF
--- a/strategies/function_calling.yaml
+++ b/strategies/function_calling.yaml
@@ -29,10 +29,9 @@ parameters:
     label:
       en_US: MCP Servers config
       zh_Hans: MCP 服务配置
-    default: "{\n  \"server_name1\": {\n    \"transport\": \"sse\",\n    \"url\": \"http://127.0.0.1:8000/sse\"\n  },
-    \n  \"server_name2\": {\n    \"transport\": \"streamable_http\",\n    \"url\": \"http://127.0.0.1:8000/mcp\"\n  }\n}"
+    default: "{\n  \"server_name1\": {\n    \"transport\": \"sse\",\n    \"url\": \"http://127.0.0.1:8000/sse\",\n    \"call_interval\": 0\n  },\n  \"server_name2\": {\n    \"transport\": \"streamable_http\",\n    \"url\": \"http://127.0.0.1:8000/mcp\",\n    \"call_interval\": 0\n  }\n}"
     help:
-      en_US: "MCP Servers config, support multiple MCP Server."
+      en_US: "MCP Servers config, support multiple MCP Server. "
       zh_Hans: "MCP服务配置，支持多个MCP服务。"
   - name: mcp_resources_as_tools
     type: boolean


### PR DESCRIPTION
新增代码是针对这个问题：
name：增加MCP的工具调用调用间隔，参数call_interval 单位秒
URL：https://github.com/junjiem/dify-plugin-agent-mcp_sse/issues/128

- Add call_interval parameter to MCP server configuration
- Implement per-server call interval control in McpClients
- Add time-based throttling in execute_tool method
- Update function_calling.yaml with call_interval examples
- Add comprehensive documentation for timeout analysis
示例：

{
  "server_name1": {
    "transport": "sse",
    "url": "http://127.0.0.1:8000/sse",
    "headers": {},
    "timeout": 50,
    "sse_read_timeout": 50,
     "call_interval ":1
  },
  "server_name2": {
    "transport": "sse",
    "url": "http://127.0.0.1:8001/sse"
  },
  "server_name3": {
    "transport": "streamable_http",
    "url": "http://127.0.0.1:8002/mcp",
    "headers": {},
    "timeout": 50
  },
  "server_name4": {
    "transport": "streamable_http",
    "url": "http://127.0.0.1:8003/mcp"
  }
}
