### PR TITLE
Update manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.4
+version: 0.2.5
 type: plugin
 author: junjiem
 name: mcp_see_agent
@@ -29,7 +29,7 @@ plugins:
   agent_strategies:
     - provider/agent.yaml
 meta:
-  version: 0.0.1
+  version: 0.0.2
   arch:
     - amd64
     - arm64


### PR DESCRIPTION
当将mcp工具添加到agent时，dify会验证meta.version> 0.0.1而决定是否生效
```python
    def _filter_mcp_type_tool(self, strategy: PluginAgentStrategy, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
        """
        Filter MCP type tool
        :param strategy: plugin agent strategy
        :param tool: tool
        :return: filtered tool dict
        """
        meta_version = strategy.meta_version
        if meta_version and Version(meta_version) > Version("0.0.1"):
            return tools
        else:
            return [tool for tool in tools if tool.get("type") != ToolProviderType.MCP.value]
```