### PR TITLE
fix: prevent history messages contain image send to unsupported model

### DIFF
--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -113,7 +113,8 @@ class ReActAgentStrategy(AgentStrategy):
                     if (
                             item.type == PromptMessageContentType.TEXT
                             or (item.type in {
-                                PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO, ModelFeature.DOCUMENT
+                                PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO,
+                                PromptMessageContentType.DOCUMENT,
                             } and ModelFeature.VISION in model.entity.features)
                             or (item.type == PromptMessageContentType.AUDIO and ModelFeature.AUDIO in model.entity.features)
                             or (item.type == PromptMessageContentType.VIDEO and ModelFeature.VIDEO in model.entity.features)


### PR DESCRIPTION
quickfix for #135 
might need more cases to improve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Conversation history is now sanitized before use: non-text items are removed for text-only models, while models with vision or richer feature support can retain images, video, or document items.
  * Expanded content-type handling for richer prompt messages, improving cross-model compatibility and response relevance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->