### PR TITLE
fix: retry when LLM return false format

### DIFF
--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -117,6 +117,7 @@ class ReActAgentStrategy(AgentStrategy):
         run_agent_state = True
         llm_usage: dict[str, Optional[LLMUsage]] = {"usage": None}
         final_answer = ""
+        empty_answer = "I am thinking about how to help you"  # the default answer when llm didn't response right format
         prompt_messages = []
 
         # Init model
@@ -247,7 +248,7 @@ class ReActAgentStrategy(AgentStrategy):
             scratchpad.thought = (
                 scratchpad.thought.strip()
                 if scratchpad.thought
-                else "I am thinking about how to help you"
+                else empty_answer
             )
             agent_scratchpad.append(scratchpad)
 
@@ -283,7 +284,10 @@ class ReActAgentStrategy(AgentStrategy):
                     else 0,
                 },
             )
-            if not scratchpad.action:
+            if not scratchpad.action and scratchpad.thought == empty_answer and iteration_step < max_iteration_steps:
+                # llm response wrong format, retry until exceed max_iteration_steps
+                run_agent_state = True
+            elif not scratchpad.action:
                 final_answer = scratchpad.thought
             else:
                 if scratchpad.action.action_name.lower() == "final answer":


### PR DESCRIPTION
LLM return empty response from time to time,
agent node will output, "I am thinking about how to help you"

with this fix, it will retry in next iteration untill it exceed

related issue:
https://github.com/langgenius/dify-official-plugins/issues/2295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added a fallback response message ("I am thinking about how to help you") that displays when the AI returns improperly formatted output
* Implemented an automatic retry mechanism that allows the agent to reprocess incomplete responses before reaching the maximum iteration limit
* Enhanced final answer determination to better distinguish between incomplete processing states and completed responses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->