### PR TITLE
fix: prevent history messages contain image send to unsupported model for FunctionCallingAgentStrategy

### DIFF
--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -113,7 +113,8 @@ class ReActAgentStrategy(AgentStrategy):
                     if (
                             item.type == PromptMessageContentType.TEXT
                             or (item.type in {
-                                PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO, ModelFeature.DOCUMENT
+                                PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO,
+                                PromptMessageContentType.DOCUMENT,
                             } and ModelFeature.VISION in model.entity.features)
                             or (item.type == PromptMessageContentType.AUDIO and ModelFeature.AUDIO in model.entity.features)
                             or (item.type == PromptMessageContentType.VIDEO and ModelFeature.VIDEO in model.entity.features)

--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -112,7 +112,12 @@ class ReActAgentStrategy(AgentStrategy):
                     for item in msg.content
                     if (
                             item.type == PromptMessageContentType.TEXT
-                            or (item.type == PromptMessageContentType.IMAGE and ModelFeature.VISION in model.entity.features)
+                            or (item.type in {
+                                PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO, ModelFeature.DOCUMENT
+                            } and ModelFeature.VISION in model.entity.features)
+                            or (item.type == PromptMessageContentType.AUDIO and ModelFeature.AUDIO in model.entity.features)
+                            or (item.type == PromptMessageContentType.VIDEO and ModelFeature.VIDEO in model.entity.features)
+                            or (item.type == PromptMessageContentType.DOCUMENT and ModelFeature.DOCUMENT in model.entity.features)
                     )
                 ]
                 new_msg = PromptMessage(
@@ -507,7 +512,6 @@ class ReActAgentStrategy(AgentStrategy):
         :param tool_instances: tool instances
         :param mcp_tool_instances: MCP tool instances
         :param message_file_ids: message file ids
-        :param trace_manager: trace manager
         :return: observation, meta
         """
         # action is tool call, invoke tool

--- a/strategies/ReAct.py
+++ b/strategies/ReAct.py
@@ -120,7 +120,7 @@ class ReActAgentStrategy(AgentStrategy):
                             or (item.type == PromptMessageContentType.DOCUMENT and ModelFeature.DOCUMENT in model.entity.features)
                     )
                 ]
-                new_msg = PromptMessage(
+                new_msg = msg.__class__(
                     role=msg.role,
                     content=filtered_content,
                     name=msg.name,

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,40 @@
+from typing import Generator
+
+from dify_plugin.entities.model import ModelFeature
+from dify_plugin.entities.model.message import PromptMessageContentType, PromptMessage
+from dify_plugin.interfaces.agent import AgentModelConfig
+
+
+class FilterHistoryMessageByModelFeaturesMixin:
+
+    @staticmethod
+    def _iter_cleanup_history_prompt_messages(model: AgentModelConfig) -> Generator[PromptMessage, None, None]:
+        """
+        remove history_prompt_message if model not support
+        :param model
+        :return:
+        """
+        for msg in model.history_prompt_messages:
+            if isinstance(msg.content, list):
+                filtered_content = [
+                    item
+                    for item in msg.content
+                    if (
+                            item.type == PromptMessageContentType.TEXT
+                            or (item.type in {
+                        PromptMessageContentType.IMAGE, PromptMessageContentType.VIDEO,
+                        PromptMessageContentType.DOCUMENT,
+                    } and ModelFeature.VISION in model.entity.features)
+                            or (item.type == PromptMessageContentType.AUDIO and ModelFeature.AUDIO in model.entity.features)
+                            or (item.type == PromptMessageContentType.VIDEO and ModelFeature.VIDEO in model.entity.features)
+                            or (item.type == PromptMessageContentType.DOCUMENT and ModelFeature.DOCUMENT in model.entity.features)
+                    )
+                ]
+                new_msg = msg.__class__(
+                    role=msg.role,
+                    content=filtered_content,
+                    name=msg.name,
+                )
+                yield new_msg
+            else:
+                yield msg

--- a/strategies/function_calling.py
+++ b/strategies/function_calling.py
@@ -31,6 +31,7 @@ from dify_plugin.interfaces.agent import (
 )
 from pydantic import BaseModel
 
+from strategies.base import FilterHistoryMessageByModelFeaturesMixin
 from utils.mcp_client import McpClients
 
 
@@ -45,7 +46,7 @@ class FunctionCallingParams(BaseModel):
     maximum_iterations: int = 3
 
 
-class FunctionCallingAgentStrategy(AgentStrategy):
+class FunctionCallingAgentStrategy(FilterHistoryMessageByModelFeaturesMixin, AgentStrategy):
     def __init__(self, runtime, session):
         super().__init__(runtime, session)
         self.query = ""
@@ -73,7 +74,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
         query = fc_params.query
         self.query = query
         self.instruction = fc_params.instruction or self.instruction
-        history_prompt_messages = fc_params.model.history_prompt_messages
+        history_prompt_messages = list(self._iter_cleanup_history_prompt_messages(fc_params.model))
         history_prompt_messages.insert(0, self._system_prompt_message)
         history_prompt_messages.append(self._user_prompt_message)
 


### PR DESCRIPTION
adding filter to clean history_prompt_messages in FunctionCallingAgentStrategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message filtering in agent strategies to ensure chat history compatibility with different AI model capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->